### PR TITLE
Update dependencies to latest versions

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -3,7 +3,6 @@
   :url "http://github.com/cosmin/clj-itunes"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.4.0"]
-                 [clj-http "0.5.8"]
-                 [org.clojure/data.json "0.2.0"]
-                 [clojurewerkz/urly "1.0.0"]])
+  :dependencies [[org.clojure/clojure "1.9.0"]
+                 [clj-http "3.9.0"]
+                 [cheshire "5.8.1"]])


### PR DESCRIPTION
Bump Clojure to version 1.9
Remove deprecated Urly library
Remove org.clojure/data.json and replace it with Cheshire
Upgrade clj-http
Remove functions from `client.clj` that aren't needed
Update tests

I've altered some of the code to due to the change in dependencies. In particular, just using `str` to create the URLs and using `:query-params` in the clj-http options map for query parameters.